### PR TITLE
Fix uninitialized constant Pathname

### DIFF
--- a/lib/let_it_go/core_ext/pathname.rb
+++ b/lib/let_it_go/core_ext/pathname.rb
@@ -1,1 +1,2 @@
+require 'pathname'
 LetItGo.watch_frozen(Pathname, :new, positions: [0])


### PR DESCRIPTION
if run directly

```
test.rb
require 'let_it_go'

ruby test.rb
uninitialized constant Pathname (NameError)
```
