### PR TITLE
Fix unused variable and shadowing outer local variable warnings

### DIFF
--- a/lib/let_it_go/report.rb
+++ b/lib/let_it_go/report.rb
@@ -7,7 +7,7 @@ module LetItGo
     end
 
     def count
-      @hash.inject(0) {|count, (k, obj)| count + obj.count; }
+      @hash.inject(0) {|count, (_k, obj)| count + obj.count; }
     end
 
     def report
@@ -26,7 +26,7 @@ module LetItGo
         }.reverse
 
       file_name_hash.each do |file_name, objects|
-        count = objects.inject(0) {|count, obj| count + obj.count }
+        count = objects.inject(0) {|sum, obj| sum + obj.count }
         @report << "  #{count}) #{file_name}\n"
         objects.each do |obj|
           @report << "    - #{obj.count}) #{obj.klass}##{obj.method_name} on line #{ obj.line_number }\n"

--- a/lib/let_it_go/wtf_parser.rb
+++ b/lib/let_it_go/wtf_parser.rb
@@ -210,7 +210,7 @@ module LetItGo
           all_methods.each do |obj|
             begin
               yield obj
-            rescue => e
+            rescue => _e
             end
           end
         else


### PR DESCRIPTION
Before this patch

```
➜  countries git:(master) ✗ bundle exec rake
/Users/Juan/.rubies/ruby-2.2.2/bin/ruby -I/Users/Juan/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib:/Users/Juan/.gem/ruby/2.2.2/gems/rspec-support-3.3.0/lib /Users/Juan/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb --color --warnings
...........................................................................................................
/Users/Juan/.gem/ruby/2.2.2/gems/let_it_go-0.0.2/lib/let_it_go/wtf_parser.rb:213:
warning: assigned but unused variable - e
/Users/Juan/.gem/ruby/2.2.2/gems/let_it_go-0.0.2/lib/let_it_go/report.rb:10:
warning: assigned but unused variable - k
/Users/Juan/.gem/ruby/2.2.2/gems/let_it_go-0.0.2/lib/let_it_go/report.rb:29:
warning: shadowing outer local variable - count

Finished in 3.63 seconds (files took 0.27267 seconds to load)
108 examples, 0 failures
```

After this patch

```
➜  countries git:(master) ✗ bundle exec rake
/Users/Juan/.rubies/ruby-2.2.2/bin/ruby -I/Users/Juan/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib:/Users/Juan/.gem/ruby/2.2.2/gems/rspec-support-3.3.0/lib /Users/Juan/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb --color --warnings
............................................................................................................

Finished in 3.9 seconds (files took 0.17417 seconds to load)
108 examples, 0 failures
```
